### PR TITLE
Allow value to be set externally; Provide a way to change and disable themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,30 @@ Add "MediumEditor" to the "predef" section in .jshintrc
 ```
 in your Ember CLI project's root.
 
+## Themes and CSS
+To change or customize the theme add `mediumEditorOptions` to your 
+`ember-cli-build.js` file. Themes available include `bootstrap`, `default`, 
+`flat`, `mani`, and `roman`. For older ember-cli versions, look in Brocfile.js.
+
+```javascript
+var app = new EmberApp(defaults, {
+  mediumEditorOptions: {
+    theme: 'bootstrap'
+  }
+});
+```
+
+To use provide your own theme set `theme: false` and provide your own css within
+your project. To remove the base styles set `excludeBaseStyles: true`.
+
+```javascript
+var app = new EmberApp(defaults, {
+  mediumEditorOptions: {
+    theme: 'bootstrap',
+    excludeBaseStyles: true
+  }
+});
+```
 
 ## Usage
 Providing the model and route are set up correctly, content typed in the contentEditable field should get bound to the ember model's attribute.

--- a/addon/components/medium-content-editable.js
+++ b/addon/components/medium-content-editable.js
@@ -33,10 +33,14 @@ export default Ember.Component.extend({
   render: function(buffer) {
     buffer.push((this.get('value') || null));
   },
+  valueDidChange: function() {
+    if (this.$() && this.get('value') !== this.$().html()) {
+      this.setContent();
+    }
+  }.observes('value'),
   setContent: function() {
-    var this_m = this;
-    if (this_m.$()) {
-      return this_m.$().html(this_m.get('value'));
+    if (this.$()) {
+      return this.$().html(this.get('value'));
     }
   }
 });

--- a/index.js
+++ b/index.js
@@ -10,12 +10,14 @@ module.exports = {
 
     this.app.import(app.bowerDirectory + '/medium-editor/dist/js/medium-editor.js');
 
-    if (options.theme && options.excludeBaseStyles !== false) {      
+    if (!options.excludeBaseStyles) {
       this.app.import(app.bowerDirectory + '/medium-editor/dist/css/medium-editor.css');
     }
 
-    if (options.theme && options.theme !== false) {
+    if (options.theme) {
       this.app.import(app.bowerDirectory + '/medium-editor/dist/css/themes/' + options.theme + '.css');
+    } else if (options.theme !== false) {
+      this.app.import(app.bowerDirectory + '/medium-editor/dist/css/themes/default.css');
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -6,9 +6,16 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
+    var options = app.options.mediumEditorOptions || {};
 
     this.app.import(app.bowerDirectory + '/medium-editor/dist/js/medium-editor.js');
-    this.app.import(app.bowerDirectory + '/medium-editor/dist/css/medium-editor.css');
-    this.app.import(app.bowerDirectory + '/medium-editor/dist/css/themes/flat.css');
+
+    if (options.theme && options.excludeBaseStyles !== false) {      
+      this.app.import(app.bowerDirectory + '/medium-editor/dist/css/medium-editor.css');
+    }
+
+    if (options.theme && options.theme !== false) {
+      this.app.import(app.bowerDirectory + '/medium-editor/dist/css/themes/' + options.theme + '.css');
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-medium-editor",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Ember cli wrapper for the Medium Editor (http://daviferreira.github.io/medium-editor)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
1) Currently the medium editor's value is only set on init. That makes it impossible to reset a form on submit, for example. This PR adds an observer that ensures the value is updated if the editor's value differs from the component's value.

2) As mentioned in issue #2, there wasn't a way to change themes or disable them. This PR adds a way to do that by passing in options in the project's Brocfile or ember-cli-build file. 
