### PR TITLE
Bump medium editor to 5.14.4 for Edge fixes

### DIFF
--- a/blueprints/ember-cli-medium-editor/index.js
+++ b/blueprints/ember-cli-medium-editor/index.js
@@ -3,6 +3,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('medium-editor', '5.13.0');
+    return this.addBowerPackageToProject('medium-editor', '5.14.4');
   }
 };


### PR DESCRIPTION
I did not test for breaking changes, but looking at the changelog I only see fixes and additions. https://github.com/yabwe/medium-editor/blob/master/CHANGES.md#5140--2016-01-31
