### PR TITLE
[Issue #13] Add an optional callback that is fired when the user finishes typing

### DIFF
--- a/addon/components/medium-content-editable.js
+++ b/addon/components/medium-content-editable.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const { computed, observer } = Ember;
+const { computed, observer, run } = Ember;
 
 export default Ember.Component.extend({
   tagName: 'div',
@@ -19,11 +19,25 @@ export default Ember.Component.extend({
     this.set('mediumEditor', _editor);
     return this.setContent();
   },
+  setUserFinishedTyping: function() {
+    if (this.get('isUserTyping')) {
+      let action = this.attrs.onFinishedTyping;
+
+      if (typeof action === 'string') {
+        this.sendAction(action);
+      } else if (typeof action === 'function') {
+        action();
+      }
+
+      return this.toggleProperty('isUserTyping');
+    }
+  },
   focusOut: function() {
-    return this.set('isUserTyping', false);
+    this.setUserFinishedTyping();
   },
   keyDown: function(event) {
     if (!event.metaKey) {
+      run.debounce(this, 'setUserFinishedTyping', 2000);
       return this.set('isUserTyping', true);
     }
   },

--- a/addon/components/medium-content-editable.js
+++ b/addon/components/medium-content-editable.js
@@ -28,12 +28,12 @@ export default Ember.Component.extend({
       } else if (typeof action === 'function') {
         action();
       }
-
-      return this.toggleProperty('isUserTyping');
     }
+
+    return this.set('isUserTyping', false);
   },
   focusOut: function() {
-    this.setUserFinishedTyping();
+    return this.setUserFinishedTyping();
   },
   keyDown: function(event) {
     if (!event.metaKey) {

--- a/addon/components/medium-content-editable.js
+++ b/addon/components/medium-content-editable.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
       let action = this.attrs.onFinishedTyping;
 
       if (typeof action === 'string') {
-        this.sendAction(action);
+        this.sendAction('onFinishedTyping');
       } else if (typeof action === 'function') {
         action();
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-medium-editor",
-  "version": "1.1.4",
+  "version": "1.2.4",
   "description": "Ember cli wrapper for the Medium Editor (http://daviferreira.github.io/medium-editor)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What is this?

Right now there is no way to know if the user finished typing.

A common use case for this would be if you want to track how long the user has been active or maybe you want to trigger an action (like a save) as soon as the user is done typing.

My proposed solution is a parameter that accepts an action:

``` handlebars
{{medium-content-editable value=model.text options=editorOptions onFinishedTyping=(action "saveContent")}}
```
## What I Did

I created a new function called `setUserFinishedTyping()` that handles setting the `isUserTyping` flag to false. This function is called in the component's `focusOut` event and also debounced (by 2 seconds) in the `keyDown` event. The idea being that if the user stops typing for at least 2 seconds the action is triggered. If the user switches form an "is typing" state to a "not typing" state, then it will execute the `onFinishedTyping` action. It accepts either a closure action or a string indicating which action to call.
### Example:

``` javascript
// app/components/note-editor.js
import Ember from 'ember';

export default Ember.Component.extend({
  // ...
  actions: {
    saveNote: function() {
      this.get('note').save();
    }
  }
});
```

``` handlebars
{{!-- app/templates/note-editor.hbs --}}
 {{medium-content-editable value=note.text options=editorOptions onFinishedTyping=(action "saveNote")}}
```

This fulfills the enhancement specified in Issue #13.
