### PR TITLE
IE10/11 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/addon/components/medium-content-editable.js
+++ b/addon/components/medium-content-editable.js
@@ -3,43 +3,71 @@ import Ember from 'ember';
 const { computed, observer } = Ember;
 
 export default Ember.Component.extend({
-  tagName: 'div',
-  attributeBindings: ['contenteditable'],
-  editable: true,
-  isUserTyping: false,
-  plaintext: false,
-  classNames: ['editable'],
-  mediumEditor: undefined,
-  contenteditable: computed('editable', function() {
-    var editable = this.get('editable');
-    return editable ? 'true' : undefined;
+  tagName:            'div',
+  attributeBindings:  ['contenteditable'],
+  editable:           true,
+  isUserTyping:       false,
+  plaintext:          false,
+  classNames:         ['editable'],
+  mediumEditor:       undefined,
+
+  contenteditable:    computed('editable', function() {
+    return this.get('editable') ? 'true' : undefined;
   }),
-  didInsertElement: function() {
-    var _editor = new MediumEditor(this.$(), this.get('options'));
+
+  triggerChange() {
+    const $el = Ember.$(this.get('element'));
+    Ember.run.next(this, function() {
+      $el.trigger('change');
+    });
+  },
+
+  didInsertElement() {
+    const _editor = new MediumEditor(this.$(), this.get('options'));
     this.set('mediumEditor', _editor);
+
+    // Setup listeners this way to support IE11 / IE10
+    // (browsers that don't natively support the input event)
+    const ctx = this;
+    Ember.run.scheduleOnce('afterRender', ctx, function() {
+      const $el = Ember.$(this.get('element'));
+      $el.bind('blue keyup paste copy cut mouseup input', this.triggerChange.bind(this));
+      Ember.$('.medium-editor-toolbar').bind('mouseup',   this.triggerChange.bind(this));
+    });
     return this.setContent();
   },
-  focusOut: function() {
-    return this.set('isUserTyping', false);
+
+  willDestroyElement() {
+    const $el = Ember.$(this.get('element'));
+    $el.unbind('blue keyup paste copy cut mouseup input', this.triggerChange.bind(this));
+    Ember.$('.medium-editor-toolbar').unbind('mouseup',   this.triggerChange.bind(this));
   },
-  keyDown: function(event) {
-    if (!event.metaKey) {
-      return this.set('isUserTyping', true);
-    }
-  },
-  input: function() {
+
+  change() {
     if (this.get('plaintext')) {
       return this.set('value', this.$().text());
     } else {
       return this.set('value', this.$().html());
     }
   },
+
+  focusOut() {
+    return this.set('isUserTyping', false);
+  },
+
+  keyDown(event) {
+    if (!event.metaKey) {
+      return this.set('isUserTyping', true);
+    }
+  },
+
   valueDidChange: observer('value', function() {
     if (this.$() && this.get('value') !== this.$().html()) {
       this.setContent();
     }
   }),
-  setContent: function() {
+
+  setContent() {
     if (this.$() && this.get('mediumEditor')) {
       this.get('mediumEditor').setContent(this.get('value'));
     }

--- a/addon/components/medium-content-editable.js
+++ b/addon/components/medium-content-editable.js
@@ -28,8 +28,7 @@ export default Ember.Component.extend({
 
     // Setup listeners this way to support IE11 / IE10
     // (browsers that don't natively support the input event)
-    const ctx = this;
-    Ember.run.scheduleOnce('afterRender', ctx, function() {
+    Ember.run.scheduleOnce('afterRender', this, function() {
       const $el = Ember.$(this.get('element'));
       $el.bind('blue keyup paste copy cut mouseup input', this.triggerChange.bind(this));
       Ember.$('.medium-editor-toolbar').bind('mouseup',   this.triggerChange.bind(this));

--- a/addon/components/medium-content-editable.js
+++ b/addon/components/medium-content-editable.js
@@ -30,7 +30,7 @@ export default Ember.Component.extend({
     // (browsers that don't natively support the input event)
     Ember.run.scheduleOnce('afterRender', this, function() {
       const $el = Ember.$(this.get('element'));
-      $el.bind('blue keyup paste copy cut mouseup input', this.triggerChange.bind(this));
+      $el.bind('blur keyup paste copy cut mouseup input', this.triggerChange.bind(this));
       Ember.$('.medium-editor-toolbar').bind('mouseup',   this.triggerChange.bind(this));
     });
     return this.setContent();
@@ -38,7 +38,7 @@ export default Ember.Component.extend({
 
   willDestroyElement() {
     const $el = Ember.$(this.get('element'));
-    $el.unbind('blue keyup paste copy cut mouseup input', this.triggerChange.bind(this));
+    $el.unbind('blur keyup paste copy cut mouseup input', this.triggerChange.bind(this));
     Ember.$('.medium-editor-toolbar').unbind('mouseup',   this.triggerChange.bind(this));
   },
 


### PR DESCRIPTION
IE11 / IE10 do not support the input event on contenteditable elements. So I refactored ember-cli-medium-editor here to fire change events that work on both IE11/IE10 as well as other browsers (chrome, firefox etc..).

I've tested it out on Chrome, FF, Safari, IE11 and IE10 and all works great. Let me know if you have any feedback. Thanks for putting this together in the first place!
