### PR TITLE
Removes medium-editor.js dependency from FastBoot builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ module.exports = {
     this._super.included(app);
     var options = app.options.mediumEditorOptions || {};
 
-    this.app.import(app.bowerDirectory + '/medium-editor/dist/js/medium-editor.js');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      this.app.import(app.bowerDirectory + '/medium-editor/dist/js/medium-editor.js');
+    }
 
     if (!options.excludeBaseStyles) {
       this.app.import(app.bowerDirectory + '/medium-editor/dist/css/medium-editor.css');


### PR DESCRIPTION
Removes FastBoot errors as detailed in #17.