### PR TITLE
Drop bower support and use npm

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,8 +2,7 @@
   "predef": [
     "document",
     "window",
-    "-Promise",
-    "MediumEditor"
+    "-Promise"
   ],
   "browser": true,
   "boss": true,

--- a/addon/components/medium-content-editable.js
+++ b/addon/components/medium-content-editable.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import MediumEditor from 'medium-editor';
 
 const { computed, observer, run } = Ember;
 

--- a/blueprints/ember-cli-medium-editor/index.js
+++ b/blueprints/ember-cli-medium-editor/index.js
@@ -1,8 +1,8 @@
-module.exports = {
-  normalizeEntityName: function() {
-  },
+/* jshint node: true */
 
-  afterInstall: function() {
-    return this.addBowerPackageToProject('medium-editor', '5.14.4');
+module.exports = {
+  description: '',
+
+  normalizeEntityName: function() {
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,25 +1,63 @@
 /* jshint node: true */
 'use strict';
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
+
+function isNotFastboot() {
+  return process.env.EMBER_CLI_FASTBOOT !== 'true';
+}
 
 module.exports = {
   name: 'ember-cli-medium-editor',
 
   included: function(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
+
     var options = app.options.mediumEditorOptions || {};
 
-    if (!process.env.EMBER_CLI_FASTBOOT) {
-      this.app.import(app.bowerDirectory + '/medium-editor/dist/js/medium-editor.js');
+    if (isNotFastboot()) {
+      this.import('vendor/medium-editor/js/medium-editor.min.js');
+      this.import('vendor/shims/medium-editor.js');
     }
 
     if (!options.excludeBaseStyles) {
-      this.app.import(app.bowerDirectory + '/medium-editor/dist/css/medium-editor.css');
+      this.import('vendor/medium-editor/css/medium-editor.min.css');
     }
 
     if (options.theme) {
-      this.app.import(app.bowerDirectory + '/medium-editor/dist/css/themes/' + options.theme + '.css');
+      this.import('vendor/medium-editor/css/themes/' + options.theme + '.min.css');
     } else if (options.theme !== false) {
-      this.app.import(app.bowerDirectory + '/medium-editor/dist/css/themes/default.css');
+      this.import('vendor/medium-editor/css/themes/default.min.css');
+    }
+  },
+
+  treeForVendor(vendorTree) {
+    var distPath = path.resolve(require.resolve('medium-editor'), '..', '..');
+    var mediumEditorTree = new Funnel(distPath, {
+      include: ['**/*'],
+      destDir: 'medium-editor'
+    });
+
+    return new MergeTrees([vendorTree, mediumEditorTree]);
+  },
+
+  // use ember-simple-auth approach 
+  // https://github.com/simplabs/ember-simple-auth/blob/1ca4ae678b7be9905076762220dcd9fcb0f27ac0/index.js#L24-L39
+  _ensureThisImport: function() {
+    if (!this.import) {
+      this._findHost = function findHostShim() {
+        var current = this;
+        var app;
+        do {
+          app = current.app || app;
+        } while (current.parent.parent && (current = current.parent));
+        return app;
+      };
+      this.import = function importShim(asset, options) {
+        var app = this._findHost();
+        app.import(asset, options);
+      };
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/lukebrenton/ember-cli-medium-editor"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^2.0.0",
+    "ember-cli-babel": "^5.1.5",
+    "medium-editor": "^5.14.4"
   }
 }

--- a/vendor/shims/medium-editor.js
+++ b/vendor/shims/medium-editor.js
@@ -1,0 +1,9 @@
+(function() {
+  function vendorModule() {
+    'use strict';
+
+    return { 'default': self['MediumEditor'] };
+  }
+
+  define('medium-editor', [], vendorModule);
+})();


### PR DESCRIPTION
Hi!
Since ember 2.11+ do not require bower we can use npm package for `medium-editor`.
I made changes as this [article](https://simplabs.com/blog/2017/02/13/npm-libs-in-ember-cli.html) suggest and tested on my project.

Since there are no tests in this project I cannot guarantee that all works the same way but again I tested it with my project and seems it is working correct.

Let me know if you have some issues I will try to fix it then.

Thanks!