### PR TITLE
Check if the element was destroyed

### DIFF
--- a/addon/components/medium-content-editable.js
+++ b/addon/components/medium-content-editable.js
@@ -37,6 +37,8 @@ export default Ember.Component.extend({
   },
 
   setUserFinishedTyping: function() {
+    if (this.isDestroyed) return;
+    
     if (this.get('isUserTyping')) {
       let action = this.attrs.onFinishedTyping;
 


### PR DESCRIPTION
Because of the debouncing, a user might run into the following error message if the text editor is destroyed after typing:

```
Failed: calling set on destroyed object: <ludu@component:medium-content-editable::ember2266>.isUserTyping
```

This fixes it by first checking `this.isDestroyed`.