### PR TITLE
Expose the MediumEditor instance

### DIFF
--- a/addon/components/medium-content-editable.js
+++ b/addon/components/medium-content-editable.js
@@ -33,6 +33,9 @@ export default Ember.Component.extend({
       $el.bind('blur keyup paste copy cut mouseup input', this.triggerChange.bind(this));
       Ember.$('.medium-editor-toolbar').bind('mouseup',   this.triggerChange.bind(this));
     });
+    
+    this.sendAction('didInit', _editor);
+    
     return this.setContent();
   },
 


### PR DESCRIPTION
This allows users to use the full [MediumEditor Object API](https://github.com/yabwe/medium-editor/blob/master/API.md) if necessary.